### PR TITLE
Solved task wrappers/UiInputDate

### DIFF
--- a/06-wrappers/06-UiInputDate/components/UiInputDate.vue
+++ b/06-wrappers/06-UiInputDate/components/UiInputDate.vue
@@ -1,5 +1,9 @@
 <template>
-  <ui-input />
+  <ui-input ref="uiInput" :type="type" v-model="modelValueProxy">
+    <template v-for="slotName of Object.keys($slots)" #[slotName]>
+      <slot :name="slotName" />
+    </template>
+  </ui-input>
 </template>
 
 <script>
@@ -9,5 +13,36 @@ export default {
   name: 'UiInputDate',
 
   components: { UiInput },
+
+  props: {
+    type: {
+      type: String,
+      default: 'date',
+      validator: value => ['date', 'time', 'datetime-local'].includes(value),
+    },
+    modelValue: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  emits: ['update:modelValue'],
+
+  computed: {
+    modelValueProxy: {
+      get() {
+        if(!this.modelValue) return '';
+
+        const dateParts = new Date(this.modelValue).toISOString().split(/T|\./)
+        if(!this.$attrs.step || !(this.$attrs.step % 60)) dateParts[1] = dateParts[1].substr(0, 5)
+        return this.type==='date' ?
+          dateParts[0] :
+          (this.type==='time' ? dateParts[1] : `${dateParts[0]}T${dateParts[1]}`)
+      },
+      set(newValue) {
+        this.$emit('update:modelValue', this.$refs.uiInput.$refs.input.valueAsNumber)
+      },
+    },
+  },
 };
 </script>

--- a/06-wrappers/06-UiInputDate/components/UiInputDate.vue
+++ b/06-wrappers/06-UiInputDate/components/UiInputDate.vue
@@ -7,6 +7,7 @@
 </template>
 
 <script>
+import { ref, computed } from 'vue';
 import UiInput from './UiInput';
 
 export default {
@@ -28,6 +29,27 @@ export default {
 
   emits: ['update:modelValue'],
 
+  setup(props, { attrs, emit }) {
+    const uiInput = ref(null)
+    const modelValueProxy = computed({
+      get() {
+        if(!props.modelValue) return '';
+
+        const dateParts = new Date(props.modelValue).toISOString().split(/T|\./)
+        if(!attrs.step || !(attrs.step % 60)) dateParts[1] = dateParts[1].substr(0, 5)
+        return props.type==='date' ?
+          dateParts[0] :
+          (props.type==='time' ? dateParts[1] : `${dateParts[0]}T${dateParts[1]}`)
+      },
+      set(newValue) {
+        emit('update:modelValue', uiInput.value.$refs.input.valueAsNumber)
+      }
+    })
+
+    return { uiInput, modelValueProxy }
+  },
+
+/*  
   computed: {
     modelValueProxy: {
       get() {
@@ -44,5 +66,6 @@ export default {
       },
     },
   },
+*/
 };
 </script>


### PR DESCRIPTION
В Composition API
`emit('update:modelValue', uiInput.value.$refs.input.valueAsNumber)`
выглядит страшно, но ничего лучше для того, чтобы обратиться к тегу <input> в дочернем компоненте, я не придумал.